### PR TITLE
[Automated] Unit Test Cases for PR #4

### DIFF
--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,36 @@
+```python
+import pytest
+from testingapp2.models import Task
+from testingapp2.actions import mark_task_completed
+from django.core.exceptions import ObjectDoesNotExist
+
+# Fixtures
+@pytest.fixture
+def create_task(db):
+    def _create_task(completed=False):
+        task = Task.objects.create(description="Test Task", completed=completed)
+        return task
+    return _create_task
+
+
+# Test Cases
+
+def test_mark_task_completed_happy_path(create_task):
+    task = create_task()
+    updated_task = mark_task_completed(task.id)
+    assert updated_task.completed is True
+    assert updated_task.id == task.id
+
+
+def test_mark_task_completed_task_not_found():
+    with pytest.raises(ObjectDoesNotExist):
+        mark_task_completed(9999) # Non-existent task ID
+
+
+def test_mark_task_completed_already_completed(create_task):
+    task = create_task(completed=True)
+    updated_task = mark_task_completed(task.id)
+    assert updated_task.completed is True
+    assert updated_task.id == task.id
+
+```

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -4,33 +4,24 @@ from testingapp2.models import Task
 from testingapp2.actions import mark_task_completed
 from django.core.exceptions import ObjectDoesNotExist
 
-# Fixtures
-@pytest.fixture
-def create_task(db):
-    def _create_task(completed=False):
-        task = Task.objects.create(description="Test Task", completed=completed)
-        return task
-    return _create_task
-
-
-# Test Cases
-
-def test_mark_task_completed_happy_path(create_task):
-    task = create_task()
+@pytest.mark.django_db
+def test_mark_task_completed_happy_path(task):
+    """Test marking a task as completed successfully."""
     updated_task = mark_task_completed(task.id)
     assert updated_task.completed is True
     assert updated_task.id == task.id
 
-
+@pytest.mark.django_db
 def test_mark_task_completed_task_not_found():
+    """Test handling a non-existent task ID."""
     with pytest.raises(ObjectDoesNotExist):
-        mark_task_completed(9999) # Non-existent task ID
+        mark_task_completed(999) # Assume ID 999 does not exist
 
 
-def test_mark_task_completed_already_completed(create_task):
-    task = create_task(completed=True)
-    updated_task = mark_task_completed(task.id)
-    assert updated_task.completed is True
-    assert updated_task.id == task.id
+@pytest.fixture
+def task(db):
+    """Fixture to create a task for testing."""
+    task = Task.objects.create(description="Test Task", completed=False)
+    return task
 
 ```

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 ```python
 import pytest
-from django.utils import timezone
 from testingapp2.models import Task
+from datetime import datetime, timedelta
 
 @pytest.fixture
 def create_task():
@@ -14,46 +14,60 @@ def test_create_task(create_task):
     assert task.title == "Test Task"
     assert task.description == "Test description"
     assert task.completed == False
-    assert task.created_at <= timezone.now()
-    assert task.updated_at <= timezone.now()
+    assert task.created_at is not None
+    assert task.updated_at is not None
 
 def test_create_task_without_description(create_task):
-    task = create_task(description="")
-    assert task.description == ""
+    task = create_task(description=None)
+    assert task.title == "Test Task"
+    assert task.description is None
+    assert task.completed == False
 
 def test_create_task_completed(create_task):
     task = create_task(completed=True)
     assert task.completed == True
 
-def test_create_task_with_long_title(create_task):
-    long_title = "a" * 256
-    with pytest.raises(Exception) as e:
-        create_task(title=long_title)
-    assert "value is too long" in str(e.value)
-
-
-def test_str_representation(create_task):
+def test_task_string_representation(create_task):
     task = create_task()
     assert str(task) == "Test Task"
 
 def test_update_task(create_task):
     task = create_task()
     original_updated_at = task.updated_at
-    task.title = "Updated Task"
+    task.title = "Updated Title"
     task.save()
-    assert task.title == "Updated Task"
+    assert task.title == "Updated Title"
     assert task.updated_at > original_updated_at
 
 
-def test_update_task_completed_status(create_task):
+def test_update_task_description(create_task):
     task = create_task()
-    task.completed = True
+    original_updated_at = task.updated_at
+    task.description = "Updated Description"
     task.save()
-    assert task.completed == True
+    assert task.description == "Updated Description"
+    assert task.updated_at > original_updated_at
 
-def test_task_creation_with_invalid_title(create_task):
+def test_task_creation_with_long_title(create_task):
+    long_title = "a" * 256
     with pytest.raises(Exception) as e:
-        Task.objects.create(title=None)
-    assert "This field cannot be blank." in str(e.value)
+        create_task(title=long_title)
+    assert "value is too long" in str(e.value)
+
+
+def test_created_at_updated_at_timestamps(create_task):
+    task = create_task()
+    created_at = task.created_at
+    updated_at = task.updated_at
+    
+    #Allow for some time difference between creation and update.
+    assert updated_at >= created_at
+
+    # Update the task and check if updated_at is updated.
+    task.title = "Updated Title"
+    task.save()
+    assert task.updated_at > updated_at
+    assert task.created_at == created_at
+
 
 ```

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,59 @@
+```python
+import pytest
+from django.utils import timezone
+from testingapp2.models import Task
+
+@pytest.fixture
+def create_task():
+    def _create_task(title="Test Task", description="Test description", completed=False):
+        return Task.objects.create(title=title, description=description, completed=completed)
+    return _create_task
+
+def test_create_task(create_task):
+    task = create_task()
+    assert task.title == "Test Task"
+    assert task.description == "Test description"
+    assert task.completed == False
+    assert task.created_at <= timezone.now()
+    assert task.updated_at <= timezone.now()
+
+def test_create_task_without_description(create_task):
+    task = create_task(description="")
+    assert task.description == ""
+
+def test_create_task_completed(create_task):
+    task = create_task(completed=True)
+    assert task.completed == True
+
+def test_create_task_with_long_title(create_task):
+    long_title = "a" * 256
+    with pytest.raises(Exception) as e:
+        create_task(title=long_title)
+    assert "value is too long" in str(e.value)
+
+
+def test_str_representation(create_task):
+    task = create_task()
+    assert str(task) == "Test Task"
+
+def test_update_task(create_task):
+    task = create_task()
+    original_updated_at = task.updated_at
+    task.title = "Updated Task"
+    task.save()
+    assert task.title == "Updated Task"
+    assert task.updated_at > original_updated_at
+
+
+def test_update_task_completed_status(create_task):
+    task = create_task()
+    task.completed = True
+    task.save()
+    assert task.completed == True
+
+def test_task_creation_with_invalid_title(create_task):
+    with pytest.raises(Exception) as e:
+        Task.objects.create(title=None)
+    assert "This field cannot be blank." in str(e.value)
+
+```

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,73 @@
+```python
+import pytest
+from rest_framework import serializers
+from testingapp2.models import Task
+from testingapp2.serializers import TaskSerializer
+
+pytestmark = pytest.mark.django_db
+
+@pytest.fixture
+def task_data():
+    return {
+        'title': 'Test Task',
+        'description': 'This is a test task.',
+        'completed': False,
+    }
+
+@pytest.fixture
+def task(task_data):
+    return Task.objects.create(**task_data)
+
+
+def test_task_serializer_happy_path(task, task_data):
+    serializer = TaskSerializer(task)
+    assert serializer.data == task_data
+
+def test_task_serializer_create_happy_path(task_data):
+    serializer = TaskSerializer(data=task_data)
+    assert serializer.is_valid() == True
+    task_instance = serializer.save()
+    assert task_instance.title == task_data['title']
+    assert task_instance.description == task_data['description']
+    assert task_instance.completed == task_data['completed']
+
+
+def test_task_serializer_update_happy_path(task, task_data):
+    new_data = {
+        'title': 'Updated Task',
+        'description': 'This is an updated task.',
+        'completed': True,
+    }
+    serializer = TaskSerializer(task, data=new_data)
+    assert serializer.is_valid() == True
+    updated_task = serializer.save()
+    assert updated_task.title == new_data['title']
+    assert updated_task.description == new_data['description']
+    assert updated_task.completed == new_data['completed']
+
+
+def test_task_serializer_missing_title(task_data):
+    missing_title_data = {
+        'description': 'Missing title',
+        'completed': False,
+    }
+    serializer = TaskSerializer(data=missing_title_data)
+    assert serializer.is_valid() == False
+    assert 'title' in serializer.errors
+
+def test_task_serializer_invalid_completed_field(task_data):
+    invalid_completed_data = {
+        'title': 'Invalid Completed',
+        'description': 'Test',
+        'completed': 'yes', #Invalid, should be boolean
+    }
+    serializer = TaskSerializer(data=invalid_completed_data)
+    assert serializer.is_valid() == False
+    assert 'completed' in serializer.errors
+
+def test_task_serializer_empty_data():
+    serializer = TaskSerializer(data={})
+    assert serializer.is_valid() == False
+    assert len(serializer.errors) > 0
+
+```

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -19,27 +19,28 @@ def task(task_data):
     return Task.objects.create(**task_data)
 
 
-def test_task_serializer_happy_path(task, task_data):
-    serializer = TaskSerializer(task)
+def test_task_serializer_happy_path(task_data, task):
+    serializer = TaskSerializer(instance=task)
     assert serializer.data == task_data
+
 
 def test_task_serializer_create_happy_path(task_data):
     serializer = TaskSerializer(data=task_data)
-    assert serializer.is_valid() == True
-    task_instance = serializer.save()
-    assert task_instance.title == task_data['title']
-    assert task_instance.description == task_data['description']
-    assert task_instance.completed == task_data['completed']
+    assert serializer.is_valid()
+    task = serializer.save()
+    assert task.title == task_data['title']
+    assert task.description == task_data['description']
+    assert task.completed == task_data['completed']
 
 
-def test_task_serializer_update_happy_path(task, task_data):
+def test_task_serializer_update_happy_path(task_data, task):
     new_data = {
         'title': 'Updated Task',
         'description': 'This is an updated task.',
         'completed': True,
     }
-    serializer = TaskSerializer(task, data=new_data)
-    assert serializer.is_valid() == True
+    serializer = TaskSerializer(instance=task, data=new_data)
+    assert serializer.is_valid()
     updated_task = serializer.save()
     assert updated_task.title == new_data['title']
     assert updated_task.description == new_data['description']
@@ -52,22 +53,28 @@ def test_task_serializer_missing_title(task_data):
         'completed': False,
     }
     serializer = TaskSerializer(data=missing_title_data)
-    assert serializer.is_valid() == False
+    assert not serializer.is_valid()
     assert 'title' in serializer.errors
 
+
 def test_task_serializer_invalid_completed_field(task_data):
-    invalid_completed_data = {
+    invalid_data = {
         'title': 'Invalid Completed',
         'description': 'Test',
-        'completed': 'yes', #Invalid, should be boolean
+        'completed': 'yes',  # Invalid type
     }
-    serializer = TaskSerializer(data=invalid_completed_data)
-    assert serializer.is_valid() == False
+    serializer = TaskSerializer(data=invalid_data)
+    assert not serializer.is_valid()
     assert 'completed' in serializer.errors
 
-def test_task_serializer_empty_data():
-    serializer = TaskSerializer(data={})
-    assert serializer.is_valid() == False
-    assert len(serializer.errors) > 0
+def test_task_serializer_too_long_title(task_data):
+    long_title_data = {
+        'title': 'a' * 256, #Assuming title field has a max_length < 256
+        'description': 'Test',
+        'completed': False,
+    }
+    serializer = TaskSerializer(data=long_title_data)
+    assert not serializer.is_valid()
+    assert 'title' in serializer.errors
 
 ```

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,39 @@
+```python
+import pytest
+from django.urls import reverse, resolve
+from testingapp import views
+
+# Happy path test cases
+
+def test_home_url_resolves():
+    url = reverse('home')
+    assert resolve(url).func == views.home
+
+def test_contact_url_resolves():
+    url = reverse('contact')
+    assert resolve(url).func == views.contact
+
+
+# Negative scenario test cases (These assume there's some validation within the views)
+
+def test_home_url_resolves_incorrect_name():
+    with pytest.raises(Exception) as e: # Replace Exception with specific exception if known
+        reverse('home_incorrect')
+    assert "NoReverseMatch" in str(e.value)
+
+def test_contact_url_resolves_incorrect_name():
+    with pytest.raises(Exception) as e: # Replace Exception with specific exception if known
+        reverse('contact_incorrect')
+    assert "NoReverseMatch" in str(e.value)
+
+
+# Example of a test case that might be needed depending on the views.  This is illustrative.
+# Test cases should be tailored to your specific views.
+
+# def test_contact_view_with_invalid_data(rf):
+#     request = rf.post('/contact/', {'name': '', 'email': 'invalid_email'})
+#     response = views.contact(request)
+#     assert response.status_code == 400 # Or whatever your error handling status code is.
+
+
+```

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -14,26 +14,30 @@ def test_contact_url_resolves():
     assert resolve(url).func == views.contact
 
 
-# Negative scenario test cases (These assume there's some validation within the views)
+# Negative scenario test cases (these assume there's some form of error handling in views.contact)
 
-def test_home_url_resolves_incorrect_name():
+def test_contact_url_invalid_method(rf): # rf is a RequestFactory fixture
+    request = rf.get(reverse('contact'))
     with pytest.raises(Exception) as e: # Replace Exception with specific exception if known
-        reverse('home_incorrect')
-    assert "NoReverseMatch" in str(e.value)
-
-def test_contact_url_resolves_incorrect_name():
-    with pytest.raises(Exception) as e: # Replace Exception with specific exception if known
-        reverse('contact_incorrect')
-    assert "NoReverseMatch" in str(e.value)
+        views.contact(request)
+    assert "Method not allowed" in str(e.value) # or adapt based on actual error handling
 
 
-# Example of a test case that might be needed depending on the views.  This is illustrative.
-# Test cases should be tailored to your specific views.
+@pytest.mark.parametrize("invalid_url", ["/contact/invalid", "/invalid"])
+def test_contact_url_invalid_path(invalid_url, client):
+    response = client.get(invalid_url)
+    assert response.status_code == 404 # Or another appropriate status code
 
-# def test_contact_view_with_invalid_data(rf):
-#     request = rf.post('/contact/', {'name': '', 'email': 'invalid_email'})
-#     response = views.contact(request)
-#     assert response.status_code == 400 # Or whatever your error handling status code is.
 
+# Fixture for RequestFactory (if not already defined in conftest.py)
+@pytest.fixture
+def rf():
+    from django.test import RequestFactory
+    return RequestFactory()
+
+@pytest.fixture
+def client():
+    from django.test import Client
+    return Client()
 
 ```

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,82 +1,42 @@
 ```python
 import pytest
-from rest_framework import status
-from rest_framework.test import APIClient
-from testingapp2.models import Task
-
-pytestmark = pytest.mark.django_db
-
-@pytest.fixture
-def create_task():
-    def _create_task(title="Test Task", completed=False):
-        return Task.objects.create(title=title, completed=completed)
-    return _create_task
+from django.urls import reverse
+from django.test import Client
 
 @pytest.fixture
 def api_client():
-    return APIClient()
+    return Client()
 
-def test_task_create(api_client, create_task):
-    data = {'title': 'New Task'}
-    response = api_client.post('/tasks/', data, format='json')
-    assert response.status_code == status.HTTP_201_CREATED
-    assert Task.objects.count() == 1
-    assert Task.objects.get(title='New Task').completed == False
+def test_home_happy_path(api_client):
+    url = reverse('home')
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello from app1!"}
 
-def test_task_create_missing_title(api_client):
-    data = {}
-    response = api_client.post('/tasks/', data, format='json')
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+def test_contact_happy_path(api_client):
+    url = reverse('contact')
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert response.json() == {"message": "Contact us!"}
 
+# Negative scenarios are difficult to implement meaningfully without 
+#  more context about potential errors (e.g., invalid requests, exceptions).
+#  The following are placeholders for negative tests; adapt as needed.
 
-def test_task_retrieve(api_client, create_task):
-    task = create_task()
-    response = api_client.get(f'/tasks/{task.pk}/')
-    assert response.status_code == status.HTTP_200_OK
-    assert response.data['title'] == task.title
-
-def test_task_retrieve_not_found(api_client):
-    response = api_client.get('/tasks/999/')
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+def test_home_invalid_method(api_client):
+    url = reverse('home')
+    response = api_client.post(url) # Or any other invalid method
+    assert response.status_code == 405 # Or appropriate error code
 
 
-def test_task_complete(api_client, create_task):
-    task = create_task()
-    response = api_client.post(f'/tasks/{task.pk}/complete/')
-    assert response.status_code == status.HTTP_200_OK
-    assert response.data['status'] == 'Task marked as completed'
-    task.refresh_from_db()
-    assert task.completed is True
+def test_contact_invalid_method(api_client):
+    url = reverse('contact')
+    response = api_client.post(url) # Or any other invalid method
+    assert response.status_code == 405 # Or appropriate error code
 
-def test_task_complete_not_found(api_client):
-    response = api_client.post('/tasks/999/complete/')
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+#Further negative tests could include:
+# - Testing for exception handling within the views (if any are implemented)
+# - Testing with different request parameters (if the views accept any)
 
-def test_task_update(api_client, create_task):
-    task = create_task()
-    data = {'title': 'Updated Task', 'completed': True}
-    response = api_client.put(f'/tasks/{task.pk}/', data, format='json')
-    assert response.status_code == status.HTTP_200_OK
-    task.refresh_from_db()
-    assert task.title == 'Updated Task'
-    assert task.completed is True
-
-def test_task_update_missing_title(api_client, create_task):
-    task = create_task()
-    data = {'completed': True}
-    response = api_client.put(f'/tasks/{task.pk}/', data, format='json')
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-
-def test_task_delete(api_client, create_task):
-    task = create_task()
-    response = api_client.delete(f'/tasks/{task.pk}/')
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-    assert Task.objects.count() == 0
-
-
-def test_task_delete_not_found(api_client):
-    response = api_client.delete('/tasks/999/')
-    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 ```

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,42 +1,77 @@
 ```python
 import pytest
-from django.urls import reverse
-from django.test import Client
+from rest_framework import status
+from rest_framework.test import APIClient
+from testingapp2.models import Task
+
+pytestmark = pytest.mark.django_db
+
+@pytest.fixture
+def create_task():
+    def _create_task(description="Test Task", completed=False):
+        return Task.objects.create(description=description, completed=completed)
+    return _create_task
 
 @pytest.fixture
 def api_client():
-    return Client()
+    return APIClient()
 
-def test_home_happy_path(api_client):
-    url = reverse('home')
-    response = api_client.get(url)
-    assert response.status_code == 200
-    assert response.json() == {"message": "Hello from app1!"}
+def test_task_creation(api_client, create_task):
+    data = {'description': 'New Task'}
+    response = api_client.post('/tasks/', data, format='json')
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Task.objects.count() == 1
+    assert Task.objects.get(description='New Task').completed == False
 
-def test_contact_happy_path(api_client):
-    url = reverse('contact')
-    response = api_client.get(url)
-    assert response.status_code == 200
-    assert response.json() == {"message": "Contact us!"}
-
-# Negative scenarios are difficult to implement meaningfully without 
-#  more context about potential errors (e.g., invalid requests, exceptions).
-#  The following are placeholders for negative tests; adapt as needed.
-
-def test_home_invalid_method(api_client):
-    url = reverse('home')
-    response = api_client.post(url) # Or any other invalid method
-    assert response.status_code == 405 # Or appropriate error code
+def test_task_creation_missing_data(api_client):
+    response = api_client.post('/tasks/', {}, format='json')
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_contact_invalid_method(api_client):
-    url = reverse('contact')
-    response = api_client.post(url) # Or any other invalid method
-    assert response.status_code == 405 # Or appropriate error code
+def test_mark_task_complete(api_client, create_task):
+    task = create_task()
+    url = f'/tasks/{task.id}/complete/'
+    response = api_client.post(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {'status': 'Task marked as completed'}
+    task.refresh_from_db()
+    assert task.completed is True
 
-#Further negative tests could include:
-# - Testing for exception handling within the views (if any are implemented)
-# - Testing with different request parameters (if the views accept any)
+def test_mark_task_complete_not_found(api_client):
+    url = '/tasks/999/complete/'  # Non-existent task ID
+    response = api_client.post(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
+def test_list_tasks(api_client, create_task):
+    create_task()
+    create_task(description="Another Task")
+    response = api_client.get('/tasks/')
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 2
+
+def test_retrieve_task(api_client, create_task):
+    task = create_task()
+    response = api_client.get(f'/tasks/{task.id}/')
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()['description'] == task.description
+
+
+def test_update_task(api_client, create_task):
+    task = create_task()
+    data = {'description': 'Updated Task Description'}
+    response = api_client.put(f'/tasks/{task.id}/', data, format='json')
+    assert response.status_code == status.HTTP_200_OK
+    task.refresh_from_db()
+    assert task.description == 'Updated Task Description'
+
+def test_delete_task(api_client, create_task):
+    task = create_task()
+    response = api_client.delete(f'/tasks/{task.id}/')
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert Task.objects.count() == 0
+
+def test_delete_task_not_found(api_client):
+    response = api_client.delete('/tasks/999/')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 ```

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,41 @@
+```python
+import pytest
+from django.urls import reverse
+from django.test import Client
+
+# Fixtures (if needed,  none explicitly needed for this simple example)
+# @pytest.fixture
+# def some_fixture():
+#     # ...
+
+
+def test_home_view_happy_path():
+    client = Client()
+    url = reverse('home')  # Assuming 'home' is the name in urls.py
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello from app1!"}
+
+
+def test_contact_view_happy_path():
+    client = Client()
+    url = reverse('contact') # Assuming 'contact' is the name in urls.py
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.json() == {"message": "Contact us!"}
+
+
+# Negative scenarios (example: testing for unexpected input - not applicable in this case without additional logic in the views)
+# def test_home_view_negative_scenario():
+#     # Example: Test with invalid input (if applicable)
+#     client = Client()
+#     url = reverse('home') + "?invalid=param"
+#     response = client.get(url)
+#     assert response.status_code == 400 # or appropriate status code
+
+# def test_contact_view_negative_scenario():
+#     # Example: Test with invalid input (if applicable) -  none explicitly needed here
+#     pass
+
+
+```

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,41 +1,82 @@
 ```python
 import pytest
-from django.urls import reverse
-from django.test import Client
+from rest_framework import status
+from rest_framework.test import APIClient
+from testingapp2.models import Task
 
-# Fixtures (if needed,  none explicitly needed for this simple example)
-# @pytest.fixture
-# def some_fixture():
-#     # ...
+pytestmark = pytest.mark.django_db
+
+@pytest.fixture
+def create_task():
+    def _create_task(title="Test Task", completed=False):
+        return Task.objects.create(title=title, completed=completed)
+    return _create_task
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+def test_task_create(api_client, create_task):
+    data = {'title': 'New Task'}
+    response = api_client.post('/tasks/', data, format='json')
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Task.objects.count() == 1
+    assert Task.objects.get(title='New Task').completed == False
+
+def test_task_create_missing_title(api_client):
+    data = {}
+    response = api_client.post('/tasks/', data, format='json')
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_home_view_happy_path():
-    client = Client()
-    url = reverse('home')  # Assuming 'home' is the name in urls.py
-    response = client.get(url)
-    assert response.status_code == 200
-    assert response.json() == {"message": "Hello from app1!"}
+def test_task_retrieve(api_client, create_task):
+    task = create_task()
+    response = api_client.get(f'/tasks/{task.pk}/')
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['title'] == task.title
+
+def test_task_retrieve_not_found(api_client):
+    response = api_client.get('/tasks/999/')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_contact_view_happy_path():
-    client = Client()
-    url = reverse('contact') # Assuming 'contact' is the name in urls.py
-    response = client.get(url)
-    assert response.status_code == 200
-    assert response.json() == {"message": "Contact us!"}
+def test_task_complete(api_client, create_task):
+    task = create_task()
+    response = api_client.post(f'/tasks/{task.pk}/complete/')
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['status'] == 'Task marked as completed'
+    task.refresh_from_db()
+    assert task.completed is True
+
+def test_task_complete_not_found(api_client):
+    response = api_client.post('/tasks/999/complete/')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+def test_task_update(api_client, create_task):
+    task = create_task()
+    data = {'title': 'Updated Task', 'completed': True}
+    response = api_client.put(f'/tasks/{task.pk}/', data, format='json')
+    assert response.status_code == status.HTTP_200_OK
+    task.refresh_from_db()
+    assert task.title == 'Updated Task'
+    assert task.completed is True
+
+def test_task_update_missing_title(api_client, create_task):
+    task = create_task()
+    data = {'completed': True}
+    response = api_client.put(f'/tasks/{task.pk}/', data, format='json')
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-# Negative scenarios (example: testing for unexpected input - not applicable in this case without additional logic in the views)
-# def test_home_view_negative_scenario():
-#     # Example: Test with invalid input (if applicable)
-#     client = Client()
-#     url = reverse('home') + "?invalid=param"
-#     response = client.get(url)
-#     assert response.status_code == 400 # or appropriate status code
+def test_task_delete(api_client, create_task):
+    task = create_task()
+    response = api_client.delete(f'/tasks/{task.pk}/')
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert Task.objects.count() == 0
 
-# def test_contact_view_negative_scenario():
-#     # Example: Test with invalid input (if applicable) -  none explicitly needed here
-#     pass
 
+def test_task_delete_not_found(api_client):
+    response = api_client.delete('/tasks/999/')
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 ```


### PR DESCRIPTION
Automatically generated unit test cases for PR #4.
        
### Test Coverage:
S.No | Scenario | Covered Unit Test Name
--- | --- | ---
1 | Test Home Url Resolves | def test_home_url_resolves
2 | Test Contact Url Resolves | def test_contact_url_resolves
3 | Test Contact Url Invalid Method | def test_contact_url_invalid_method
4 | Test Contact Url Invalid Path | def test_contact_url_invalid_path
5 | Test Home Happy Path | def test_home_happy_path
6 | Test Contact Happy Path | def test_contact_happy_path
7 | Test Home Invalid Method | def test_home_invalid_method
8 | Test Contact Invalid Method | def test_contact_invalid_method
9 | Test Mark Task Completed Happy Path | def test_mark_task_completed_happy_path
10 | Test Mark Task Completed Task Not Found | def test_mark_task_completed_task_not_found
11 | Test Create Task | def test_create_task
12 | Test Create Task Without Description | def test_create_task_without_description
13 | Test Create Task Completed | def test_create_task_completed
14 | Test Task String Representation | def test_task_string_representation
15 | Test Update Task | def test_update_task
16 | Test Update Task Description | def test_update_task_description
17 | Test Task Creation With Long Title | def test_task_creation_with_long_title
18 | Test Created At Updated At Timestamps | def test_created_at_updated_at_timestamps
19 | Test Task Serializer Happy Path | def test_task_serializer_happy_path
20 | Test Task Serializer Create Happy Path | def test_task_serializer_create_happy_path
21 | Test Task Serializer Update Happy Path | def test_task_serializer_update_happy_path
22 | Test Task Serializer Missing Title | def test_task_serializer_missing_title
23 | Test Task Serializer Invalid Completed Field | def test_task_serializer_invalid_completed_field
24 | Test Task Serializer Too Long Title | def test_task_serializer_too_long_title
25 | Test Task Creation | def test_task_creation
26 | Test Task Creation Missing Data | def test_task_creation_missing_data
27 | Test Mark Task Complete | def test_mark_task_complete
28 | Test Mark Task Complete Not Found | def test_mark_task_complete_not_found
29 | Test List Tasks | def test_list_tasks
30 | Test Retrieve Task | def test_retrieve_task
31 | Test Update Task | def test_update_task
32 | Test Delete Task | def test_delete_task
33 | Test Delete Task Not Found | def test_delete_task_not_found

        
### Test Execution Summary:
Some tests failed. Please review.

#### Detailed Results:
```
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/happyfox/learn/testcase-generator/testcase-generator script
plugins: anyio-4.8.0
collected 4 items

test_urls.py FF                                                          [ 50%]
test_views.py FF                                                         [100%]

=================================== FAILURES ===================================
____________________________ test_home_url_resolves ____________________________
test_urls.py:5: in test_home_url_resolves
    url = reverse('home')
../aitotest/lib/python3.13/site-packages/django/urls/base.py:30: in reverse
    resolver = get_resolver(urlconf)
../aitotest/lib/python3.13/site-packages/django/urls/resolvers.py:110: in get_resolver
    urlconf = settings.ROOT_URLCONF
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:81: in __getattr__
    self._setup(name)
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:61: in _setup
    raise ImproperlyConfigured(
E   django.core.exceptions.ImproperlyConfigured: Requested setting ROOT_URLCONF, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
__________________________ test_contact_url_resolves ___________________________
test_urls.py:10: in test_contact_url_resolves
    url = reverse('contact')
../aitotest/lib/python3.13/site-packages/django/urls/base.py:30: in reverse
    resolver = get_resolver(urlconf)
../aitotest/lib/python3.13/site-packages/django/urls/resolvers.py:110: in get_resolver
    urlconf = settings.ROOT_URLCONF
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:81: in __getattr__
    self._setup(name)
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:61: in _setup
    raise ImproperlyConfigured(
E   django.core.exceptions.ImproperlyConfigured: Requested setting ROOT_URLCONF, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
________________________________ test_home_view ________________________________
test_views.py:17: in test_home_view
    url = reverse('home')  # Assuming 'home' is the name in urls.py
../aitotest/lib/python3.13/site-packages/django/urls/base.py:30: in reverse
    resolver = get_resolver(urlconf)
../aitotest/lib/python3.13/site-packages/django/urls/resolvers.py:110: in get_resolver
    urlconf = settings.ROOT_URLCONF
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:81: in __getattr__
    self._setup(name)
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:61: in _setup
    raise ImproperlyConfigured(
E   django.core.exceptions.ImproperlyConfigured: Requested setting ROOT_URLCONF, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
______________________________ test_contact_view _______________________________
test_views.py:24: in test_contact_view
    url = reverse('contact') # Assuming 'contact' is the name in urls.py
../aitotest/lib/python3.13/site-packages/django/urls/base.py:30: in reverse
    resolver = get_resolver(urlconf)
../aitotest/lib/python3.13/site-packages/django/urls/resolvers.py:110: in get_resolver
    urlconf = settings.ROOT_URLCONF
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:81: in __getattr__
    self._setup(name)
../aitotest/lib/python3.13/site-packages/django/conf/__init__.py:61: in _setup
    raise ImproperlyConfigured(
E   django.core.exceptions.ImproperlyConfigured: Requested setting ROOT_URLCONF, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
=========================== short test summary info ============================
FAILED test_urls.py::test_home_url_resolves - django.core.exceptions.Improper...
FAILED test_urls.py::test_contact_url_resolves - django.core.exceptions.Impro...
FAILED test_views.py::test_home_view - django.core.exceptions.ImproperlyConfi...
FAILED test_views.py::test_contact_view - django.core.exceptions.ImproperlyCo...
============================== 4 failed in 1.36s ===============================

```
        